### PR TITLE
feat: improve inventory overlay tooltips

### DIFF
--- a/src/items/weapons/sword.py
+++ b/src/items/weapons/sword.py
@@ -17,7 +17,7 @@ class Sword(Weapon):
             "critVariance": 5
         }
         self.stats["categories"] = self.base_categories + ["sword"]
-        self.stats["description"] = "The sword given to you by your father on your\n 13th birthday. Your name is engraved upon it"
+        self.stats["description"] = "The sword given to you by your father on your 13th birthday. Your name is engraved upon it"
         if self.cache_key not in self._cache:
             self._cache[self.cache_key] = pygame.image.load(
                 asset("items", "weapon", "sword.png")

--- a/src/menu/image.py
+++ b/src/menu/image.py
@@ -1,7 +1,9 @@
 import pygame
 
+
 class Image(pygame.sprite.Sprite):
     """Basic Image"""
+
     def __init__(self, image, game, pos, **kwargs):
         # Load image while attempting to use a predefined image if provided
         if image:
@@ -44,9 +46,10 @@ class Image(pygame.sprite.Sprite):
 
         # Ensure that at least one render is preformed (if update isn't called)
         self.render()
-    def drawBG(self, colorIndex = 0):
+
+    def drawBG(self, colorIndex=0):
         """Draw the background color depending on the provided index.
-        
+
         Arguments:
         -----
         colorIndex: int = 0
@@ -55,6 +58,7 @@ class Image(pygame.sprite.Sprite):
                 - `colorIndex < len(self.colors)
         """
         self.image.fill(self.colors[colorIndex])
+
     def update(self):
         self.hover = False
         self.clicked = False
@@ -72,11 +76,13 @@ class Image(pygame.sprite.Sprite):
                     if self.onClick:
                         self.onClick(self)
         self.render()
+
     def render(self):
         # Draw background
-        self.drawBG(int(self.hover)) # Typecast from bool to int (True/False) -> (1/0)
+        self.drawBG(int(self.hover))  # Typecast from bool to int (True/False) -> (1/0)
 
         # Draw the image
         self.image.blit(self.trueImage, (0, 0))
+
     def setClickHandler(self, fn):
         self.onClick = fn

--- a/src/menu/text.py
+++ b/src/menu/text.py
@@ -1,11 +1,13 @@
 import pygame
 from stgs import aalias, fonts
 
+
 class Text(pygame.sprite.Sprite):
     '''
     Text object with multiline support
     '''
-    def __init__(self, fNum, text, color, aalias=True, pos=(0, 0), multiline=False, size=(900, 600), bgColor=(0, 0, 0, 0), **kwargs): 
+
+    def __init__(self, fNum, text, color, aalias=True, pos=(0, 0), multiline=False, size=(900, 600), bgColor=(0, 0, 0, 0), **kwargs):
         if isinstance(fNum, str):
             self.font = fonts[fNum]
         else:
@@ -23,9 +25,10 @@ class Text(pygame.sprite.Sprite):
         self.setText(text, multiline)
 
         super().__init__(self.groups)
-    def setText(self, text, multiline = False):
+
+    def setText(self, text, multiline=False):
         if multiline:
-            ## This code is thanks to https://stackoverflow.com/questions/42014195/rendering-text-with-multiple-lines-in-pygame 
+            # This code is thanks to https://stackoverflow.com/questions/42014195/rendering-text-with-multiple-lines-in-pygame 
             self.image = pygame.Surface(self.size, pygame.SRCALPHA)
             self.image.fill(self.bgColor)
             words = [word.split(' ') for word in text.splitlines()]  # 2D array where each row is a list of words.
@@ -34,7 +37,7 @@ class Text(pygame.sprite.Sprite):
             x, y = 0, 0
             for line in words:
                 for word in line:
-                    if word  != '':
+                    if word != '':
                         if word[0:3] == "RGB":
                             wordsplit = word[4:].split(')')
                             word_color = tuple([int(x) for x in wordsplit[0].split(',')])
@@ -48,10 +51,12 @@ class Text(pygame.sprite.Sprite):
                             y += word_height  # Start on new row.
                         self.image.blit(word_surface, (x, y))
                         x += word_width + space
-                x = 0 # Reset the x.
+                x = 0  # Reset the x.
                 y += word_height  # Start on new row.
-        else: 
+
+            self.last_rendered_y = y
+        else:
             self.image = self.font.render(text, aalias, self.color)
-        
+
         self.rect = pygame.Rect(self.pos.x, self.pos.y, self.image.get_width(), self.image.get_height())
         self.image = self.image.convert_alpha()

--- a/src/overlay/inventory.py
+++ b/src/overlay/inventory.py
@@ -32,7 +32,8 @@ class InventoryOverlay(Overlay):
         self.tooltip_id = None
 
         # Random settings
-        self.maxToolTipSize = 400
+        self.maxToolTipSize = 300
+        self.padding = 8
 
     def load_comps(self):
         """Loads all of the components"""
@@ -301,26 +302,19 @@ class InventoryOverlay(Overlay):
                             True,
                             (255, 255, 255)
                         )
-                        # tooltip_desc = main_font.render(
-                        #     item_comp.tooltip[1],
-                        #     True,
-                        #     (255, 255, 255)
-                        # )
                         tooltip_desc = menu.Text(
                             fgen("ComicSansMS.ttf", 12),
                             item_comp.tooltip[1],
                             colors.white,
-                            True
+                            True,
+                            multiline=True,
+                            size=(self.maxToolTipSize - self.padding * 2, 900)
                         )
 
                         # Determine the size of the box we need
-                        width = min(
-                            max(
-                                tooltip_title.get_size()[0],
-                                tooltip_desc.rect.width
-                            ) + 4,
-                            self.maxToolTipSize
-                        )
+                        width = self.maxToolTipSize
+                        height = tooltip_title.get_height() + tooltip_desc.last_rendered_y \
+                            + self.padding * 3  # 3 to account for padding between title and desc
 
                         # Draw the box
                         pygame.draw.rect(
@@ -330,20 +324,23 @@ class InventoryOverlay(Overlay):
                                 item_comp.rect.x + item_comp.rect.width + 5,
                                 item_comp.rect.y,
                                 width,
-                                50
+                                height
                             )
                         )
 
+                        title_y = item_comp.rect.y + self.padding
+                        desc_y = title_y + tooltip_title.get_height() + self.padding
+
                         # Draw on the title
                         tooltip_surf.blit(tooltip_title, (
-                            item_comp.rect.x + item_comp.rect.width + 7,
-                            item_comp.rect.y + 2,
+                            item_comp.rect.x + item_comp.rect.width + 5 + self.padding,
+                            title_y
                         ))
 
                         # Draw on the description
                         tooltip_surf.blit(tooltip_desc.image, (
-                            item_comp.rect.x + item_comp.rect.width + 7,
-                            item_comp.rect.y + 20
+                            item_comp.rect.x + item_comp.rect.width + 5 + self.padding,
+                            desc_y
                         ))
 
                         # Blit the tooltip surface onto the overlay surface


### PR DESCRIPTION
Adds a proper sense of padding to the tooltip calculations (this sorta existed before but used hardcoded constants). Additionally, the height of tooltip boxes are now dynamically set based upon the height of the total tooltip content.