### PR TITLE
feat: switch to pygame-ce

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "moderngl>=5.12.0",
-    "pygame>=2.6.1",
+    "pygame-ce>=2.5.3",
     "pytmx>=3.32",
 ]
 authors = ["LGgameLAB", "Ben Landon"]
@@ -17,3 +17,6 @@ dev = [
     "flameprof>=0.4",
     "pep8-naming>=0.14.1",
 ]
+
+[tool.ruff]
+line-length = 100

--- a/src/game.py
+++ b/src/game.py
@@ -22,14 +22,12 @@ from sfx import *
 from util import *
 import menus
 import hud
-# from PygameShader.shader import shader_sobel24_fast_inplace, shader_bloom_effect_array24
-# from PygameShader.gaussianBlur5x5 import blur5x5_array24_inplace_c
-
 
 
 class Grouper:
     '''A class to control and manipulate multiple groups (pygame.group.Group)
     of game objects that is mainly designed for in code control'''
+
     def __init__(self):
         """Contains helpful groups for organizing different types of sprites"""
         # Create sprite groups here
@@ -40,7 +38,7 @@ class Grouper:
         self.pProjectiles = Group()  # Player Projectiles
         self.eProjectiles = Group()  # Enemy Projectiles
 
-    def getProximitySprites(self, sprite, proximity=300, groups=[]): 
+    def getProximitySprites(self, sprite, proximity=300, groups=[]):
         """Returns a list of sprites that fall within the specified proximity\
         to the specified sprite.
 
@@ -64,11 +62,11 @@ class Grouper:
                     returnList.append(ent)
 
         return returnList
-    
+
     def clearAll(self):
         for g in self.allGroups():
             g.empty()
-    
+
     def killAll(self):
         for g in self.allGroups():
             for s in g:
@@ -77,12 +75,14 @@ class Grouper:
     def allGroups(self):
         return [self.__dict__[g] for g in self.__dict__ if isinstance(self.__dict__[g], Group)]
 
+
 #### Game object ####
 class Game:
     """Represents an instance of the game"""
+
     def __init__(self):
         """Initializes the game object"A Very Very Long Description.
-        
+
         Groups each sprite type to perform targetted tasks
         All sprites go into the sprites group
         Sets up window, font, gravity, and cam
@@ -134,7 +134,7 @@ class Game:
         )
         self.inventoryOverlay = InventoryOverlay(self)
         self.pauseScreen = PauseOverlay(self)
-        #self.mapScreen = MapOverlay(self)
+        # self.mapScreen = MapOverlay(self)
         self.dialogueScreen = DialogueOverlay(self)
         self.statsInfo = hud.StatHud(self, border = asset("objects/dPallette3.png")) 
         self.slots = hud.SlotsHud(self)
@@ -142,7 +142,6 @@ class Game:
         self.sanityHud = hud.SanityHud(self)
         self.updateT = pygame.time.get_ticks()
         self.cam = Cam(self, winWidth, winHeight)
-        
 
     ####  Determines how the run will function ####
     def run(self):
@@ -161,13 +160,13 @@ class Game:
         self.dialogueScreen.dialogueFromText("Well Hello")
         while not self.end:
             self.clock.tick(FPS)
-            self.refresh()#asset('objects/shocking.jpg'))
+            self.refresh()  # asset('objects/shocking.jpg'))
 
-            ##Updates Game
+            # Updates Game
             self.runEvents()
             self.update()
 
-    def update(self): 
+    def update(self):
         self.getFps()
         self.getPause()
         if self.pause:
@@ -180,7 +179,7 @@ class Game:
             self.checkHits()
         self.overlayer.update()
         self.cam.update()
-        
+
         self.render()
 
         self.display.update(self.win)
@@ -194,10 +193,10 @@ class Game:
                 #     if pygame.Rect(0, 0, winWidth, winHeight).colliderect(self.cam.apply(sprite)):
                 #         self.win.blit(sprite.image, self.cam.apply(sprite))
                 sprite.draw(self.win, self.cam.applyRect)
-        
+
         for fx in self.fxLayer:
             self.win.blit(fx.image, fx.rect)
-        
+
         self.renderDarkness()
 
         for sprite in self.hudLayer:
@@ -214,7 +213,7 @@ class Game:
                     self.win.blit(sprite.image, sprite.rect)
             except AttributeError:
                 self.win.blit(sprite.image, sprite.rect)
-        
+
         if self.showFps:
             fpsText = fonts['caption1'].render(str(round(self.currentFps, 2)), self.antialiasing, (255, 255, 255))
             self.win.blit(fpsText, (1100, 5))
@@ -223,11 +222,11 @@ class Game:
             pos = self.player.cursor.pos
             size = self.player.cursor.size
             pygame.draw.rect(self.win, (200, 0, 0), (pos.x, pos.y, size.x, size.y))
-        
+
         # shader_bloom_effect_array24(self.win, 0, fast_=True)
-        
+
         # self.win.blit(self.player.getAttackMask(), (0, 0))
-        
+
     def renderDarkness(self):
         darkness = pygame.Surface((winWidth, winWidth))
         lightRect = pygame.Rect(0, 0, self.player.lightSource.get_width(), self.player.lightSource.get_height())
@@ -237,7 +236,6 @@ class Game:
             darkness.blit(sprite.sourceImg, self.cam.apply(sprite))
 
         self.win.blit(darkness, (0, 0), special_flags=pygame.BLEND_MULT)
-
 
     def checkHits(self):
         pygame.sprite.groupcollide(self.groups.colliders, self.groups.pProjectiles, False, True)
@@ -249,16 +247,18 @@ class Game:
             self.mixer.playFx('pHit')
             self.hudLayer.update()
             self.pause = True
+
             def cont():
                 if True:
                     self.cam.target = self.player
                     self.pause = False
                     self.groups.enemies.empty()
                     self.map.switchLevel('cave1')
-                    #self.player.reset()
+                    # self.player.reset()
                     self.fxLayer.empty()
                     for s in self.pSprites:
                         s.kill()
+
             def died():
                 Button(self, (400, 400), groups = [self.pSprites, self.overlayer], text = "Continue", onClick=cont, instaKill = True, center = True, colors = (colors.orangeRed, colors.white))
                 def end():
@@ -294,46 +294,41 @@ class Game:
         pygame.quit()
         sys.exit()
 
-    def runEvents(self):    
+    def runEvents(self):
         ## Catch all events here
         self.events = pygame.event.get()
         for event in self.events:
             if event.type == pygame.QUIT:
                 self.quit()
-        
+
             if event.type == pygame.KEYDOWN:
                 if event.key == pygame.K_ESCAPE:
-                    if self.fullScreen:
-                        self.win = pygame.display.set_mode((winWidth, winHeight))
-                        self.fullScreen = False
-                        pygame.display.set_icon(pygame.image.load(iconPath))
-                    else:
-                        self.quit()
+                    self.quit()
 
         if pygame.time.get_ticks() - self.lastCamTog >= 400 and checkKey(keySet['toggleCam']):
             self.toggleCam()
             self.lastCamTog = pygame.time.get_ticks()
-        
+
         # Inventory
         if checkKey(keySet["inventory"]) and self.inventoryOverlay.can_activate():
             self.toggleInventory()
 
     def getFps(self):
-        self.currentFps = self.clock.get_fps() 
+        self.currentFps = self.clock.get_fps()
         return self.currentFps
-    
+
     def dt(self):
         return self.clock.get_time()*0.001
-    
+
     def dt2(self):
         return self.clock.get_time()*0.06
-    
+
     def toggleCam(self):
         self.cam.toggleTarget()
 
     def toggleFps(self):
         self.showFps = not self.showFps
-    
+
     def toggleInventory(self):
         if self.inInventory:
             self.closeInventory()
@@ -343,7 +338,7 @@ class Game:
     def openInventory(self):
         self.inInventory = True
         self.inventoryOverlay.activate()
-    
+
     def closeInventory(self):
         self.inInventory = False
         self.inventoryOverlay.deactivate()
@@ -353,8 +348,7 @@ class Game:
 
     def toggleAalias(self):
         self.antialiasing = not self.antialiasing
-        self.pauseScreen.loadComponents()
-
+        self.pauseScreen.load_components()
 
     def getPause(self):
         if pygame.time.get_ticks() - self.lastPause >= 60:
@@ -366,17 +360,13 @@ class Game:
                     self.pauseScreen.activate()
 
                 self.lastPause = pygame.time.get_ticks()
-                
+
     def getSprBylID(self, lID):
         for sprite in self.sprites:
-            try:
-                if sprite.lID == lID:
-                    return sprite
-            except:
-                pass
+            if getattr(sprite, "lID", False):
+                return sprite
         return False
 
-    #### First menu loop ####
     def menuLoop(self):
         menus.main(self, True)
 
@@ -386,7 +376,7 @@ class Game:
     def gameOver(self):
         menus.gameOver(self)
 
-    def refresh(self, bg = False):
+    def refresh(self, bg=False):
         """Updates the background
 
         If bg is True, the provided image is used, otherwise the solid color black is used
@@ -395,4 +385,3 @@ class Game:
             self.win.blit(pygame.transform.scale(bg, (winWidth, winHeight)), (0, 0))
         else:
             self.win.fill((0, 0, 0))
-

--- a/src/menu/button.py
+++ b/src/menu/button.py
@@ -2,22 +2,23 @@ import pygame
 from stgs import fonts
 import colors
 
+
 class Button(pygame.sprite.Sprite):
     '''
     A menu object that that stores a clicked value when hovered over
 
     Arguments
     |    Button.text [str] - stores optional text value
-    |    Button.colors [tup] - Stores colors 
+    |    Button.colors [tup] - Stores colors
     |    Button.center [bool] - Stores whether text is centered or not
 
     Values
     |    Button.clicked [bool] - stores whether it has been clicked or ot since initiation
     |    Button.
     '''
-    def __init__(self, game, pos,**kwargs):
+
+    def __init__(self, game, pos, **kwargs):
         self.game = game
-        
         self.onClick = False
         self.groups = []
         self.wh = (200, 60)
@@ -41,9 +42,10 @@ class Button(pygame.sprite.Sprite):
         self.image = pygame.Surface(self.rect.size, pygame.SRCALPHA)
         self.image.fill((255, 0, 0, 0))
         self.setText(self.text)
-    def setText(self, text, color = 0):
+
+    def setText(self, text, color=0):
         """Sets the button's text
-        
+
         Arguments:
         -----
         text: string,
@@ -67,6 +69,7 @@ class Button(pygame.sprite.Sprite):
         else:
             self.textRect.x += 2
             self.textRect.y += 2
+
     def update(self):
         self.image = pygame.Surface(self.rect.size, pygame.SRCALPHA)
         self.image.fill((0, 0, 0, 0))
@@ -75,7 +78,7 @@ class Button(pygame.sprite.Sprite):
         mouseRect = pygame.Rect(pygame.mouse.get_pos()[0], pygame.mouse.get_pos()[1], 1, 1)
         if mouseRect.colliderect(self.rect):
             self.hover = True
-        
+
         if self.hover:
             for event in self.game.events:
                 if event.type == pygame.MOUSEBUTTONDOWN:
@@ -87,9 +90,10 @@ class Button(pygame.sprite.Sprite):
                             self.kill()
 
         self.drawBG(int(self.hover))
-        
+
         self.image.blit(self.rendText, self.textRect)
-    def drawBG(self, colorIndex = 0):
+
+    def drawBG(self, colorIndex=0):
         if self.rounded:
             borderRadius = 15
         else:
@@ -103,5 +107,6 @@ class Button(pygame.sprite.Sprite):
         )
         self.setText(self.text, colorIndex)
         return
+
     def reset(self):
         self.clicked = False

--- a/src/menu/image.py
+++ b/src/menu/image.py
@@ -5,17 +5,6 @@ class Image(pygame.sprite.Sprite):
     """Basic Image"""
 
     def __init__(self, image, game, pos, **kwargs):
-        # Load image while attempting to use a predefined image if provided
-        if image:
-            # Make a copy - not a reference
-            self.trueImage = image.copy().convert_alpha()
-            self.image = pygame.Surface((64, 64)).convert_alpha()
-        else:
-            # No predefined
-            self.trueImage = pygame.Surface((1, 1), pygame.SRCALPHA)
-            self.trueImage.fill((0, 0, 0, 0))
-            self.image = pygame.Surface((64, 64)).convert_alpha()
-
         # Colors [normal, hover]
         self.colors = [(50, 50, 50), (40, 40, 40)]
 
@@ -41,8 +30,19 @@ class Image(pygame.sprite.Sprite):
         for key, value in kwargs.items():
             self.__dict__[key] = value
 
-        self.rect = pygame.Rect(self.x, self.y, self.width, self.height)
         super().__init__(self.groups)
+        self.rect = pygame.Rect(self.x, self.y, self.width, self.height)
+
+        # Load image while attempting to use a predefined image if provided
+        if image:
+            # Make a copy - not a reference
+            self.trueImage = image.copy().convert_alpha()
+            self.image = pygame.Surface((64, 64)).convert_alpha()
+        else:
+            # No predefined
+            self.trueImage = pygame.Surface((1, 1), pygame.SRCALPHA)
+            self.trueImage.fill((0, 0, 0, 0))
+            self.image = pygame.Surface((64, 64)).convert_alpha()
 
         # Ensure that at least one render is preformed (if update isn't called)
         self.render()

--- a/src/menu/settingSlider.py
+++ b/src/menu/settingSlider.py
@@ -1,16 +1,16 @@
 import pygame
 import colors
 
+
 class SettingSlider(pygame.sprite.Sprite):
     '''
-    A menu object that acts as a basic slider that stores it's value as a percentage ( use SettingSlider.getRatio() )
+    A menu object that acts as a basic slider that stores it's value as a percentage
+    (use SettingSlider.getRatio())
     It renders itself using pygame draw methods and color values given as SettingSlider.colors
     '''
-    
-    def __init__(self, game, pos,**kwargs):
+
+    def __init__(self, game, pos, **kwargs):
         self.game = game
-        self.rect = (0, 0, 200, 60)
-        self.sliderRect = (0, 0, 20, 10)
         self.bgColor = (0, 0, 0, 0)
         #          line (normal)           Rect
         self.colors = (colors.orangeRed, colors.yellow, (255, 255, 255))
@@ -18,18 +18,18 @@ class SettingSlider(pygame.sprite.Sprite):
         self.text = ''
         self.center = False
 
-        self.groups = []       ## These few lines are the lines for component objects
+        self.groups = []  # These few lines are the lines for component objects
         self.addGroups = []
         for k, v in kwargs.items():
             self.__dict__[k] = v
-        
+
         self.groups = self.groups + self.addGroups
         pygame.sprite.Sprite.__init__(self, self.groups)
 
-        self.rect = pygame.Rect(self.rect)
+        self.rect = pygame.Rect((0, 0, 200, 60))
         self.rect.x, self.rect.y = pos
         self.image = pygame.Surface(self.rect.size, pygame.SRCALPHA)
-        self.sliderRect = pygame.Rect(self.sliderRect)
+        self.sliderRect = pygame.Rect((0, 0, 20, 10))
         self.sliderRect.centery = self.rect.height/2
         self.sliderRect.x = self.rect.width - self.sliderRect.width
 
@@ -37,34 +37,48 @@ class SettingSlider(pygame.sprite.Sprite):
         self.sliderRect = pygame.Rect(self.sliderRect)
         self.sliderRect.centery = self.rect.height/2
         self.sliderRect.x = self.rect.width - self.sliderRect.width
-    
+
     def update(self):
         if self.clicked:
-            if not pygame.mouse.get_pressed()[0]:  
-               self.clicked = False
+            if not pygame.mouse.get_pressed()[0]:
+                self.clicked = False
             else:
-                self.sliderRect.x = min(self.rect.right-self.sliderRect.width, pygame.mouse.get_pos()[0]-self.sliderRect.width) - self.rect.x
+                self.sliderRect.x = min(
+                    self.rect.right-self.sliderRect.width,
+                    pygame.mouse.get_pos()[0]-self.sliderRect.width
+                ) - self.rect.x
                 self.sliderRect.x = max(0, self.sliderRect.x)
         else:
             self.checkClicked()
-        
+
         self.render()
-    
+
     def get_ratio(self):
         return self.sliderRect.x/(self.rect.width-self.sliderRect.width)
-    
-    def setRatio(self, percent): # Set between 0 & 1
+
+    def setRatio(self, percent):  # Set between 0 & 1
         self.sliderRect.x = (self.rect.width-self.sliderRect.width)*percent
 
     def render(self):
         self.image.fill(self.bgColor)
-        pygame.draw.line(self.image, self.colors[1],(0, self.rect.height/2), (self.sliderRect.centerx, self.rect.height/2), 4)
-        pygame.draw.line(self.image, self.colors[0],(self.sliderRect.centerx, self.rect.height/2), (self.rect.width, self.rect.height/2), 4)
+        pygame.draw.line(
+            self.image,
+            self.colors[1],
+            (0, self.rect.height/2),
+            (self.sliderRect.centerx, self.rect.height/2),
+            4
+        )
+        pygame.draw.line(
+            self.image,
+            self.colors[0],
+            (self.sliderRect.centerx, self.rect.height/2),
+            (self.rect.width, self.rect.height/2),
+            4
+        )
         pygame.draw.rect(self.image, self.colors[2], self.sliderRect)
 
-    
     def checkClicked(self):
-        if pygame.mouse.get_pressed()[0]: 
+        if pygame.mouse.get_pressed()[0]:
             mouseRect = pygame.Rect(pygame.mouse.get_pos()[0], pygame.mouse.get_pos()[1], 1, 1)
             if mouseRect.colliderect(self.rect):
                 self.clicked = True

--- a/src/menu/text.py
+++ b/src/menu/text.py
@@ -22,9 +22,9 @@ class Text(pygame.sprite.Sprite):
         for key, value in kwargs.items():
             self.__dict__[key] = value
 
-        self.setText(text, multiline)
-
         super().__init__(self.groups)
+
+        self.setText(text, multiline)
 
     def setText(self, text, multiline=False):
         if multiline:

--- a/src/objects/projectiles.py
+++ b/src/objects/projectiles.py
@@ -3,9 +3,10 @@ import util
 import colors
 import math
 import fx
-from stgs import asset, FPS
+from stgs import asset
 from .lights import LightSource, LightEffect
 from animations import BasicAnimation
+
 
 class Projectile(util.Sprite):
     def __init__(self, game, pos, target, **kwargs):
@@ -13,22 +14,27 @@ class Projectile(util.Sprite):
         self.game = game
         self.offset = 0
         self.vel = 10
-        self.image = pygame.image.load(asset("player/s1.png"))
         for k, v in kwargs.items():
             self.__dict__[k] = v
-        
+
         pygame.sprite.Sprite.__init__(self, self.groups)
+
+        self.image = pygame.image.load(asset("player/s1.png"))
 
         self.pos = pygame.Vector2(pos)
         self.dir = pygame.Vector2(target).normalize()
         self.dir = self.dir.rotate(self.offset)
-        self.image = pygame.transform.rotate(self.image, math.degrees(math.atan2(-target.y, target.x)) - self.offset - 135)
+        self.image = pygame.transform.rotate(
+            self.image,
+            math.degrees(math.atan2(-target.y, target.x)) - self.offset - 135
+        )
         self.rect = pygame.Rect(0, 0, self.image.get_width(), self.image.get_height())
         self.rect.center = self.pos
-        ## If you were thinking this should be on the then well . . . I did it here to be more precise
-        # fx.Particles(self.game, self.rect, lifeSpan = 100, tickSpeed=20, size = 8).setParticleKwargs(speed=1.5, shrink=0.4, life=140, color=colors.orangeRed)
+        # If you were thinking this should be on the then well . . .
+        # I did it here to be more precise
+        # fx.Particles(self.game, self.rect, lifeSpan = 100, tickSpeed=20, size = 8)
+        #     .setParticleKwargs(speed=1.5, shrink=0.4, life=140, color=colors.orangeRed)
 
-    
     def update(self):
         self.pos += self.dir * self.vel * self.game.dt() * 60
         self.rect.center = self.pos
@@ -36,34 +42,41 @@ class Projectile(util.Sprite):
             if hasattr(e, 'image'):
                 if pygame.sprite.collide_mask(self, e):
                     self.hit(e)
-    
+
     def hit(self, enemy=None):
         dmg = self.game.player.stats.attack()
-        if enemy != None:
+        if enemy is not None:
             enemy.takeDamage(dmg[0])
             self.game.player.combatParts.particle(self.pos, dmg[0], dmg[1])
-        
+
         self.kill()
+
 
 class Fireball(Projectile):
     def __init__(self, game):
-        mPos = pygame.Vector2(pygame.mouse.get_pos()) - pygame.Vector2(game.cam.apply(game.player).center)
-        super().__init__(game, game.player.rect.center, mPos, groups=(game.sprites, game.layer2, game.groups.pProjectiles))
+        mPos = pygame.Vector2(pygame.mouse.get_pos()) \
+                - pygame.Vector2(game.cam.apply(game.player).center)
+        super().__init__(
+            game,
+            game.player.rect.center,
+            mPos,
+            groups=(game.sprites, game.layer2, game.groups.pProjectiles)
+        )
         self.imgSheet = {'main': asset('player/fireball.png')}
         self.animations = BasicAnimation(self)
         self.animations.delay = 30
         self.image = self.animations.getFirstFrame()
         self.rect = pygame.Rect(0, 0, self.image.get_width(), self.image.get_height())
         self.rect.center = self.pos
-        self.particles = fx.Particles(self.game, self.rect, tickSpeed=20, size = 8)
+        self.particles = fx.Particles(self.game, self.rect, tickSpeed=20, size=8)
         self.particles.setParticleKwargs(speed=1.2, shrink=0.4, life=100, color=colors.orangeRed)
         self.light = LightSource(game, self.rect, img=asset("objects/light1.png"))
-    
+
     def update(self):
         super().update()
         self.light.rect.center = self.rect.center
         self.animations.update()
-    
+
     def kill(self):
         self.particles.setLife(220)
         LightEffect(self.game, self.rect)

--- a/src/util/display.py
+++ b/src/util/display.py
@@ -1,17 +1,17 @@
 import pygame
 import moderngl
 from src.shaders import ShaderManager, Shader
-from src.stgs import *
+from src.stgs import winWidth, winHeight, winFlags, keySet, now, TITLE, iconPath
+
 
 class Display:
-
     def __init__(self):
         self.resolution = pygame.display.list_modes()[0]
         # self.display = pygame.display.set_mode(self.resolution)
         self.display = pygame.display.set_mode((winWidth, winHeight), winFlags)
         pygame.display.set_caption(TITLE)
         pygame.display.set_icon(pygame.image.load(iconPath))
-        self.display.convert(32, pygame.RLEACCEL) 
+        self.display.convert(32, pygame.RLEACCEL)
         self.fullScreen = False
         self.last_pressed_fullscreen = 0
 
@@ -29,17 +29,20 @@ class Display:
                 self.display = pygame.display.set_mode((winWidth, winHeight), winFlags)
                 self.fullScreen = False
             else:
-                self.display = pygame.display.set_mode((winWidth, winHeight), winFlags | pygame.FULLSCREEN)
+                self.display = pygame.display.set_mode(
+                    (winWidth, winHeight),
+                    winFlags | pygame.FULLSCREEN
+                )
                 self.fullScreen = True
             pygame.display.set_icon(pygame.image.load(iconPath))
-            #pygame.display.toggle_fullscreen()
-    
+            # pygame.display.toggle_fullscreen()
+
     def update(self, window):
         # See if the player toggles fullscreen
         self.getFullScreen()
 
-        self.display.blit(window, (0, 0)) 
-        frame_texture = self.get_frame() # Convert display to shader texture
+        self.display.blit(window, (0, 0))
+        frame_texture = self.get_frame()  # Convert display to shader texture
         self.shaderManager.apply(frame_texture)
 
         self.ctx.screen.use()
@@ -52,7 +55,7 @@ class Display:
     # Blit passthrough
     def blit(self, img, rect):
         self.display.blit(img, rect)
-    
+
     def get_size(self):
         return self.display.get_size()
 
@@ -65,12 +68,11 @@ class Display:
         tex.swizzle = 'BGRA'
         tex.write(surf.get_view('1'))
         return tex
-    
-    def render_pass(shader_pass, texture):
+
+    def render_pass(self, shader_pass, texture):
         """Render a pass using the given framebuffer, input texture, and shader program"""
         shader_pass.fbo.use()
         self.ctx.clear()
         texture.use(0)
         shader_pass.program['tex'] = 0
         shader_pass.render_object.render(mode=moderngl.TRIANGLE_STRIP)
-

--- a/uv.lock
+++ b/uv.lock
@@ -97,18 +97,18 @@ wheels = [
 ]
 
 [[package]]
-name = "pygame"
-version = "2.6.1"
+name = "pygame-ce"
+version = "2.5.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/49/cc/08bba60f00541f62aaa252ce0cfbd60aebd04616c0b9574f755b583e45ae/pygame-2.6.1.tar.gz", hash = "sha256:56fb02ead529cee00d415c3e007f75e0780c655909aaa8e8bf616ee09c9feb1f", size = 14808125 }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/4b/c08d748c8b082cee786e09b65a126d391c39b28dc75e3cea036b4b47b9dd/pygame_ce-2.5.3.tar.gz", hash = "sha256:dc04f0bf1a270a84eb371556298a9902b9c4ab08137c9dd10ef03fa4e7fcbfed", size = 6987675 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/91/718acf3e2a9d08a6ddcc96bd02a6f63c99ee7ba14afeaff2a51c987df0b9/pygame-2.6.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ae6039f3a55d800db80e8010f387557b528d34d534435e0871326804df2a62f2", size = 13090765 },
-    { url = "https://files.pythonhosted.org/packages/0e/c6/9cb315de851a7682d9c7568a41ea042ee98d668cb8deadc1dafcab6116f0/pygame-2.6.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2a3a1288e2e9b1e5834e425bedd5ba01a3cd4902b5c2bff8ed4a740ccfe98171", size = 12381704 },
-    { url = "https://files.pythonhosted.org/packages/9f/8f/617a1196e31ae3b46be6949fbaa95b8c93ce15e0544266198c2266cc1b4d/pygame-2.6.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:27eb17e3dc9640e4b4683074f1890e2e879827447770470c2aba9f125f74510b", size = 13581091 },
-    { url = "https://files.pythonhosted.org/packages/3b/87/2851a564e40a2dad353f1c6e143465d445dab18a95281f9ea458b94f3608/pygame-2.6.1-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4c1623180e70a03c4a734deb9bac50fc9c82942ae84a3a220779062128e75f3b", size = 14273844 },
-    { url = "https://files.pythonhosted.org/packages/85/b5/aa23aa2e70bcba42c989c02e7228273c30f3b44b9b264abb93eaeff43ad7/pygame-2.6.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef07c0103d79492c21fced9ad68c11c32efa6801ca1920ebfd0f15fb46c78b1c", size = 13951197 },
-    { url = "https://files.pythonhosted.org/packages/a6/06/29e939b34d3f1354738c7d201c51c250ad7abefefaf6f8332d962ff67c4b/pygame-2.6.1-cp313-cp313-win32.whl", hash = "sha256:3acd8c009317190c2bfd81db681ecef47d5eb108c2151d09596d9c7ea9df5c0e", size = 10249309 },
-    { url = "https://files.pythonhosted.org/packages/7e/11/17f7f319ca91824b86557e9303e3b7a71991ef17fd45286bf47d7f0a38e6/pygame-2.6.1-cp313-cp313-win_amd64.whl", hash = "sha256:813af4fba5d0b2cb8e58f5d95f7910295c34067dcc290d34f1be59c48bd1ea6a", size = 10620084 },
+    { url = "https://files.pythonhosted.org/packages/2c/10/85e3a06b5b3dee5770e3ccb1d78ef629a4d220df14c5ca95774b30562241/pygame_ce-2.5.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:6a60622da82b16ebb5da95bd6f3a6fc41d312ec0505c9333ec0eeaed74c78123", size = 13712664 },
+    { url = "https://files.pythonhosted.org/packages/7f/dd/d3e6b15887eaf327594b63cd91fda96b3011d21a79368df4d82bbf23d4ac/pygame_ce-2.5.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4326d7914a2ff8eea987bb4d16a1caa9a65921308eeb26c6d1f66cd6a1a5a930", size = 12965944 },
+    { url = "https://files.pythonhosted.org/packages/b9/e6/c7f80dd888a05f2290cc7ef0e492cca48cded0bf34073e57405e9757d35e/pygame_ce-2.5.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e2d25dd15fffc0e0e528d41941943b3775874aa66e171a5e8f86845fbc93518f", size = 13588585 },
+    { url = "https://files.pythonhosted.org/packages/c2/65/ad9db36d76ed4706f547c957f127beb30f60fe76ccc8da8cbc4f364b015d/pygame_ce-2.5.3-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4f0c0e34008165b93a543d5ce526f8d6459662779c2f9ddc77ef3446329b2cc6", size = 14129006 },
+    { url = "https://files.pythonhosted.org/packages/e5/96/e33fad39c931805927b723519607e4b0d8ecec4690541d265a9141e19734/pygame_ce-2.5.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c3ccb1f170cc3fd52d4c4c8575e29689b90b04db089b3c3cbb331955fdde244f", size = 13765876 },
+    { url = "https://files.pythonhosted.org/packages/6a/d3/6c968e7044f47ddcc277fc6790c64b0cf2f1f10c3ae5b07fe8c6b458a870/pygame_ce-2.5.3-cp313-cp313-win32.whl", hash = "sha256:6ed3cc5b1c1c2580579569f76b2109843429cc66ca68e8bc7d9e0eb4224cae00", size = 11064408 },
+    { url = "https://files.pythonhosted.org/packages/32/ce/d6dae18f3c3ee07a80054145973ed1da4c7b413eab03c6008b81b42ecb5b/pygame_ce-2.5.3-cp313-cp313-win_amd64.whl", hash = "sha256:308f432559ae60ad04316777792d49df1f84f22bbb67a374a38ee15e8d97bdba", size = 11620106 },
 ]
 
 [[package]]
@@ -126,7 +126,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "moderngl" },
-    { name = "pygame" },
+    { name = "pygame-ce" },
     { name = "pytmx" },
 ]
 
@@ -140,7 +140,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "moderngl", specifier = ">=5.12.0" },
-    { name = "pygame", specifier = ">=2.6.1" },
+    { name = "pygame-ce", specifier = ">=2.5.3" },
     { name = "pytmx", specifier = ">=3.32" },
 ]
 


### PR DESCRIPTION
Switch to pygame-ce for improved wayland support. A lot of the classes needed some modification because pygame-ce Sprite.__init__ overwrites the self.rect and self.image properties, thereby breaking the subclasses. This was fixed by simply moving the initialization of those properties to after the call to super().__init__()